### PR TITLE
Move mi_loss() random sampling functions to deepali.core

### DIFF
--- a/deepali/core/__init__.py
+++ b/deepali/core/__init__.py
@@ -40,6 +40,8 @@ from .grid import grid_vectors_transform
 from .grid import grid_transform_points
 from .grid import grid_transform_vectors
 
+from .random import multinomial
+
 from .types import Array
 from .types import Batch
 from .types import Dataclass
@@ -105,6 +107,7 @@ __all__ = (
     "join_kwargs_in_sequence",
     "make_parent_dir",
     "make_temp_file",
+    "multinomial",
     "is_bool_dtype",
     "is_float_dtype",
     "is_int_dtype",

--- a/deepali/core/functional.py
+++ b/deepali/core/functional.py
@@ -87,6 +87,7 @@ from .image import grid_sample
 from .image import grid_sample_mask
 from .image import image_slice
 from .image import normalize_image
+from .image import rand_sample
 from .image import rescale
 from .image import sample_image
 from .image import spatial_derivatives
@@ -220,6 +221,7 @@ __all__ = (
     "ones_image",
     "polyline_directions",
     "polyline_tangents",
+    "rand_sample",
     "rescale",
     "sample_flow",
     "sample_image",

--- a/deepali/core/image.py
+++ b/deepali/core/image.py
@@ -1233,7 +1233,7 @@ def rand_sample(
         mask = mask.flatten(2).squeeze(1)
         index = multinomial(mask, num_samples, replacement=replacement, generator=generator)
     index = index.unsqueeze(1).repeat(1, shape[1], 1)
-    out = [torch.gather(x, dim=2, index=index) for x in input]
+    out = [x.gather(2, index) for x in input]
     if len(out) == 1 and isinstance(data, Tensor):
         return out[0]
     return out

--- a/deepali/core/image.py
+++ b/deepali/core/image.py
@@ -1230,7 +1230,7 @@ def rand_sample(
             raise ValueError("rand_sample() 'mask' has different spatial shape than 'data'")
         if mask.shape[1] != 1:
             raise ValueError("rand_sample() 'mask' must be scalar image tensor")
-        mask = mask.flatten(2).squeeze(1)
+        mask = mask.flatten(2).squeeze(1).expand(shape[0], numel)
         index = multinomial(mask, num_samples, replacement=replacement, generator=generator)
     index = index.unsqueeze(1).repeat(1, shape[1], 1)
     out = [x.gather(2, index) for x in input]

--- a/deepali/core/random.py
+++ b/deepali/core/random.py
@@ -1,0 +1,51 @@
+r"""Auxiliary functions for random sampling."""
+
+from typing import Optional
+
+import torch
+from torch import Generator, LongTensor, Tensor
+
+
+def multinomial(
+    input: Tensor,
+    num_samples: int,
+    replacement: bool = False,
+    generator: Optional[Generator] = None,
+    out: Optional[LongTensor] = None,
+) -> LongTensor:
+    r"""Sample from a multinomial probability distribution.
+
+    Args:
+        input: Input vector of shape ``(N,)`` or matrix ``(M, N)``.
+        num_samples: Number of random samples to draw.
+        replacement: Whether to sample with or without replacement.
+        generator: Random number generator to use.
+        out: Pre-allocated output tensor.
+
+    Returns:
+        Indices of random samples. When ``input`` is a vector, a vector of ``num_sampled`` indices
+        is returned. Otherwise, a matrix of shape ``(M, num_samples)`` is returned. When ``out``
+        is given, the returned tensor is a reference to ``out``.
+
+    """
+    if input.ndim == 0 or input.ndim > 2:
+        raise ValueError("multinomial() 'input' must be vector or matrix")
+    num_candidates = input.size(-1)
+    # torch.multinomial() works only for at most 2^24 categories.
+    if num_candidates <= 2**24:
+        out = torch.multinomial(
+            input, num_samples, replacement=replacement, generator=generator, out=out
+        )
+    # Use inverse transform sampling if the number of candidates is large and replacement=True
+    elif replacement:
+        cdf = torch.cumsum(input / input.sum(dim=-1, keepdim=True), dim=-1)
+        cdf = torch.divide(cdf, cdf[..., -1].unsqueeze(-1), out=cdf)
+        val = torch.rand(input.shape[:-1] + (num_samples,), dtype=input.dtype, device=input.device)
+        out = torch.searchsorted(cdf, val, out=out)
+        out = torch.clip(out, 0, num_candidates - 1, out=out)
+    # In case of replacement=False, use Gumbel-max trick instead of inverse transform sampling.
+    else:
+        raise NotImplementedError(
+            f"multinomial() 'replacement=False' for an input with more than {2**24} elements"
+        )
+    return out

--- a/deepali/core/random.py
+++ b/deepali/core/random.py
@@ -1,6 +1,7 @@
 r"""Auxiliary functions for random sampling."""
 
 from typing import Optional
+import warnings
 
 import torch
 from torch import Generator, LongTensor, Tensor
@@ -24,7 +25,7 @@ def multinomial(
         out: Pre-allocated output tensor.
 
     Returns:
-        Indices of random samples. When ``input`` is a vector, a vector of ``num_sampled`` indices
+        Indices of random samples. When ``input`` is a vector, a vector of ``num_samples`` indices
         is returned. Otherwise, a matrix of shape ``(M, num_samples)`` is returned. When ``out``
         is given, the returned tensor is a reference to ``out``.
 
@@ -34,21 +35,61 @@ def multinomial(
     num_candidates = input.size(-1)
     if not replacement and num_candidates < num_samples:
         raise ValueError("multinomial() 'num_samples' cannot be greater than number of categories")
-    # torch.multinomial() works only for at most 2^24 categories.
-    if num_candidates <= 2**24:
-        out = torch.multinomial(
-            input, num_samples, replacement=replacement, generator=generator, out=out
-        )
+    impl = _multinomial if num_candidates > 2**24 else torch.multinomial
+    return impl(input, num_samples, replacement=replacement, generator=generator, out=out)
+
+
+def _multinomial(
+    input: Tensor,
+    num_samples: int,
+    replacement: bool = False,
+    generator: Optional[Generator] = None,
+    out: Optional[LongTensor] = None,
+) -> LongTensor:
+    r"""Sample from a multinomial probability distribution.
+
+    This function can be used for inputs of any size and is unlike ``torch.multinomial`` not limited
+    to 2**24 categories at the expense of a less efficient implementation.
+
+    Args:
+        input: Input vector of shape ``(N,)`` or matrix ``(M, N)``.
+        num_samples: Number of random samples to draw.
+        replacement: Whether to sample with or without replacement.
+        generator: Random number generator to use.
+        out: Pre-allocated output tensor.
+
+    Returns:
+        Indices of random samples. When ``input`` is a vector, a vector of ``num_samples`` indices
+        is returned. Otherwise, a matrix of shape ``(M, num_samples)`` is returned. When ``out``
+        is given, the returned tensor is a reference to ``out``.
+
+    """
+    if input.ndim == 0 or input.ndim > 2:
+        raise ValueError("_multinomial() 'input' must be vector or matrix")
+    num_candidates = input.size(-1)
     # Use inverse transform sampling if the number of candidates is large and replacement=True
-    elif replacement:
-        cdf = torch.cumsum(input / input.sum(dim=-1, keepdim=True), dim=-1)
-        cdf = torch.divide(cdf, cdf[..., -1].unsqueeze(-1), out=cdf)
-        val = torch.rand(input.shape[:-1] + (num_samples,), dtype=input.dtype, device=input.device)
-        out = torch.searchsorted(cdf, val, out=out)
-        out = torch.clip(out, 0, num_candidates - 1, out=out)
+    if replacement:
+        cdf = input.type(torch.float64).cumsum(dim=-1)
+        cdf = cdf.div_(cdf[..., -1:].clone())
+        val = torch.rand(
+            cdf.shape[:-1] + (num_samples,),
+            generator=generator,
+            dtype=cdf.dtype,
+            device=cdf.device,
+        )
+        out = torch.searchsorted(cdf, val, out=out).clip_(0, num_candidates - 1)
     # In case of replacement=False, use Gumbel-max trick instead of inverse transform sampling.
     else:
+        if num_samples > num_candidates:
+            raise ValueError(
+                "_multinomial() 'num_samples' cannot be greater than number of categories"
+            )
+        if generator is not None:
+            warnings.warn(
+                "_multinomial() with 'replacement=False' currently ignores 'generator' argument"
+            )
         gumbels: Tensor = Gumbel(0, 1).sample(input.shape[:-1] + (num_candidates,))
-        out = torch.argsort(gumbels.add_(input), dim=-1, descending=True)
-        out = out.narrow(-1, 0, num_samples)
+        indices = torch.argsort(gumbels.to(input).add_(input), dim=-1, descending=True)
+        indices = indices.narrow(-1, 0, num_samples)
+        out = indices if out is None else out.copy_(indices)
     return out

--- a/tests/test_core_random.py
+++ b/tests/test_core_random.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from torch import Tensor
 
+from deepali.core.kernels import gaussian1d
 from deepali.core.random import _multinomial
 
 
@@ -10,7 +11,7 @@ def generator() -> torch.Generator:
     return torch.Generator("cpu").manual_seed(123456789)
 
 
-def test_multinomial_with_replacement(generator) -> None:
+def test_multinomial_with_replacement(generator: torch.Generator) -> None:
     r"""Test weighted sampling with replacement using inverse transform sampling."""
 
     input = torch.arange(1000)
@@ -54,8 +55,18 @@ def test_multinomial_with_replacement(generator) -> None:
         assert index.shape == (10,)
         assert subset[index].ge(100).le(200).all()
 
+    # Sample from a spatial Gaussian distribution
+    num_samples = 1_000_000
+    input = gaussian1d(5)
+    index = _multinomial(input, num_samples, replacement=True, generator=generator)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (num_samples,)
+    freq = index.bincount().div(num_samples)
+    assert freq.allclose(input, rtol=0.1)
 
-def test_multinomial_without_replacement(generator) -> None:
+
+def test_multinomial_without_replacement(generator: torch.Generator) -> None:
     r"""Test weighted sampling without replacement using Gumbel-max trick."""
 
     input = torch.arange(1000)
@@ -90,3 +101,20 @@ def test_multinomial_without_replacement(generator) -> None:
     assert isinstance(index, Tensor)
     assert index.dtype == torch.int64
     assert index.shape == (3, 10)
+
+    # No duplicates
+    subset = input.clone()
+    subset[subset.lt(100)] = 0
+    subset[subset.gt(200)] = 0
+    subset[subset.gt(0)] = 1
+
+    num_samples = 10
+    num_repeat = 100
+
+    for _ in range(num_repeat):
+        index = _multinomial(subset, num_samples, replacement=False, generator=generator)
+        assert isinstance(index, Tensor)
+        assert index.dtype == torch.int64
+        assert index.shape == (num_samples,)
+        assert index.unique().shape == (num_samples,)
+        assert subset[index].eq(1).all()

--- a/tests/test_core_random.py
+++ b/tests/test_core_random.py
@@ -1,0 +1,92 @@
+import pytest
+import torch
+from torch import Tensor
+
+from deepali.core.random import _multinomial
+
+
+@pytest.fixture
+def generator() -> torch.Generator:
+    return torch.Generator("cpu").manual_seed(123456789)
+
+
+def test_multinomial_with_replacement(generator) -> None:
+    r"""Test weighted sampling with replacement using inverse transform sampling."""
+
+    input = torch.arange(1000)
+
+    # Input checks
+    with pytest.raises(ValueError):
+        _multinomial(torch.tensor(0), 1, replacement=True)
+    with pytest.raises(ValueError):
+        _multinomial(torch.ones((1, 2, 3)), 1, replacement=True)
+
+    index = _multinomial(torch.ones(10), 11, replacement=True)  # no exception
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (11,)
+
+    # Output type and shape
+    index = _multinomial(input, 10, replacement=True)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (10,)
+
+    index = _multinomial(input.unsqueeze(0), 10, replacement=True)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (1, 10)
+
+    index = _multinomial(input.unsqueeze(0).repeat(3, 1), 10, replacement=True)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (3, 10)
+
+    # Only samples with non-zero weight
+    subset = input.clone()
+    subset[subset.lt(100)] = 0
+    subset[subset.gt(200)] = 0
+
+    for _ in range(10):
+        index = _multinomial(subset, 10, replacement=True, generator=generator)
+        assert isinstance(index, Tensor)
+        assert index.dtype == torch.int64
+        assert index.shape == (10,)
+        assert subset[index].ge(100).le(200).all()
+
+
+def test_multinomial_without_replacement(generator) -> None:
+    r"""Test weighted sampling without replacement using Gumbel-max trick."""
+
+    input = torch.arange(1000)
+
+    # Input checks
+    with pytest.raises(ValueError):
+        _multinomial(torch.tensor(0), 1, replacement=False)
+    with pytest.raises(ValueError):
+        _multinomial(torch.ones((1, 2, 3)), 1, replacement=False)
+
+    index = _multinomial(torch.ones(10), 10, replacement=False)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (10,)
+    assert index.sort().values.eq(torch.arange(10)).all()
+
+    with pytest.raises(ValueError):
+        _multinomial(torch.ones(10), 11, replacement=False)
+
+    # Output type and shape
+    index = _multinomial(input, 10, replacement=False)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (10,)
+
+    index = _multinomial(input.unsqueeze(0), 10, replacement=False)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (1, 10)
+
+    index = _multinomial(input.unsqueeze(0).repeat(3, 1), 10, replacement=False)
+    assert isinstance(index, Tensor)
+    assert index.dtype == torch.int64
+    assert index.shape == (3, 10)


### PR DESCRIPTION
Following up on #1 by @qiuhuaqi , moving random sampling functions to `deepali.core` and generalizing these.
