### PR TITLE
tmp fix of center_crop

### DIFF
--- a/src/deepali/data/image.py
+++ b/src/deepali/data/image.py
@@ -667,7 +667,7 @@ class ImageBatch(DataTensor):
 
         """
         size = cat_scalars(size, *args, num=self.sdim, device=self.device)
-        data = U.center_crop(self, size)
+        data = U.center_crop(self.tensor(), size)
         grid = tuple(grid.center_crop(size) for grid in self._grid)
         return self._make_instance(data, grid)
 


### PR DESCRIPTION
 `Image.center_crop` passes itself (self) to the underlying function which assumes the input to be torch.Tensor.
A better fix should be done in `Image.__getitem__ `