### PR TITLE
[enh] Add SpatialTransform.points() and PointSetTransformer module

### DIFF
--- a/docs/reference/spatial/transformer.md
+++ b/docs/reference/spatial/transformer.md
@@ -11,3 +11,10 @@
 .. automodule:: deepali.spatial.ImageTransformer
     :noindex:
 ```
+
+## Point set transformer
+
+```{eval-rst}
+.. automodule:: deepali.spatial.PointSetTransformer
+    :noindex:
+```

--- a/src/deepali/core/grid.py
+++ b/src/deepali/core/grid.py
@@ -65,7 +65,7 @@ class Axes(Enum):
     def from_arg(cls, arg: Union[Axes, str, None]) -> Axes:
         r"""Create enumeration value from function argument."""
         if arg is None or arg == "default":
-            return cls.CUBE
+            return cls.CUBE_CORNERS if ALIGN_CORNERS else cls.CUBE
         return cls(arg)
 
     @classmethod

--- a/src/deepali/spatial/__init__.py
+++ b/src/deepali/spatial/__init__.py
@@ -87,6 +87,7 @@ from .bspline import StationaryVelocityFreeFormDeformation
 # Spatial transformers based on a coordinate transformation
 from .image import ImageTransform  # noqa
 from .transformer import ImageTransformer  # noqa
+from .transformer import PointSetTransformer  # noqa
 
 
 # Aliases
@@ -168,6 +169,7 @@ __all__ = (
         "LinearTransform",
         "NonRigidTransform",
         "ParametricTransform",
+        "PointSetTransformer",
         "ReadOnlyParameters",
         "SpatialTransform",
         "TransformConfig",


### PR DESCRIPTION
The `SpatialTransform.points()` method can be used instead of `SpatialTransform.forward()` when the input point coordinates are not normalized with respect to the `SpatialTransform.grid()` and `SpatialTransform.axes()`, or when the output point coordinates should be mapped to a different domain as part of applying this function. This is mainly a convenience function, but should also make applying spatial transformations to unnormalized points (e.g., w.r.t. to the world coordinate system) more clear.

In addition, the `PointSetTransformer` module calls the `SpatialTransform.points()` function to transform a given input. The arguments of the `SpatialTransform.points()` method are hereby set during transformer module initialization.

Closes #53.