### PR TITLE
[enh] Add SpatialTransformer base class; SpatialTransform.register_update_hook and remove_update_hook()

### DIFF
--- a/src/deepali/spatial/__init__.py
+++ b/src/deepali/spatial/__init__.py
@@ -85,7 +85,8 @@ from .bspline import FreeFormDeformation
 from .bspline import StationaryVelocityFreeFormDeformation
 
 # Spatial transformers based on a coordinate transformation
-from .image import ImageTransform  # noqa
+from .image import ImageTransform  # noqa (deprecated)
+from .transformer import SpatialTransformer  # noqa
 from .transformer import ImageTransformer  # noqa
 from .transformer import PointSetTransformer  # noqa
 
@@ -172,6 +173,7 @@ __all__ = (
         "PointSetTransformer",
         "ReadOnlyParameters",
         "SpatialTransform",
+        "SpatialTransformer",
         "TransformConfig",
         "affine_first",
         "has_affine_component",

--- a/src/deepali/spatial/base.py
+++ b/src/deepali/spatial/base.py
@@ -49,7 +49,7 @@ class SpatialTransform(DeviceProperty, Module, metaclass=ABCMeta):
         self._grid = grid
         self._args = ()
         self._kwargs = {}
-        self.register_forward_pre_hook(self.update_hook)
+        self.register_update_hook()
 
     def __copy__(self: TSpatialTransform) -> TSpatialTransform:
         r"""Make shallow copy of this transformation.
@@ -390,10 +390,20 @@ class SpatialTransform(DeviceProperty, Module, metaclass=ABCMeta):
         return self
 
     @staticmethod
-    def update_hook(transform: Module, *args, **kwargs) -> None:
+    def _update_hook(transform: Module, *args, **kwargs) -> None:
         r"""Update callback which is registered as pre-forward hook."""
         assert isinstance(transform, SpatialTransform)
         transform.update()
+
+    def register_update_hook(self) -> None:
+        r"""Register a forward pre-hook which invokes :meth:`.SpatialTransform.update`."""
+        self._update_hook_handle = self.register_forward_pre_hook(self._update_hook)
+
+    def remove_update_hook(self) -> None:
+        r"""Remove previously registered :meth:`.SpatialTransform.update` hook."""
+        if self._update_hook_handle is not None:
+            self._update_hook_handle.remove()
+            self._update_hook_handle = None
 
     @property
     def inv(self: TSpatialTransform) -> TSpatialTransform:

--- a/src/deepali/spatial/transformer.py
+++ b/src/deepali/spatial/transformer.py
@@ -21,71 +21,37 @@ from ..modules import SampleImage
 from .base import SpatialTransform
 
 
-class ImageTransformer(Module):
-    r"""Spatially transform an image.
+class SpatialTransformer(Module):
+    r"""Spatially transform input data.
 
-    The :class:`.ImageTransformer` applies a :class:`.SpatialTransform` to the sampling grid
-    points of the target domain, optionally followed by linear transformation from target to
-    source domain, and samples the input image of shape ``(N, C, ..., X)`` at these deformed
-    source grid points. If the spatial transformation is non-rigid, this is also commonly
-    referred to as warping the input image.
+    A :class:`.SpatialTransformer` applies a :class:`.SpatialTransform` to a given input. How the spatial
+    transformation is applied to produce a transformed output is determined by the type of spatial transformer.
+
+    The forward method of a spatial transformer invokes the spatial transform as a functor such that any registered
+    pre-forward and post-forward hooks are executed as part of the spatial transform evaluation. This includes
+    in particular the :meth:`.SpatialTransform.update` function if the :meth:`.SpatialTransform.update_hook`
+    is registered as pre-forward hook of the spatial transform. Note that this hook is by default installed during
+    initialization of a spatial transform. When the update of spatial transform parameters, which may be inferred by
+    a neural network, is done explicitly by the application, use :meth:`.SpatialTransform.remove_update_hook` to
+    remove the pre-forward update hook before subsequent evaluations of the spatial transform. When doing so, ensure
+    to update the parameters when necessary using either :meth:`.SpatialTransformer.update` or
+    :meth:`.SpatialTransform.update`, respectively.
 
     """
 
-    def __init__(
-        self,
-        transform: SpatialTransform,
-        target: Optional[Grid] = None,
-        source: Optional[Grid] = None,
-        sampling: Union[Sampling, str] = Sampling.LINEAR,
-        padding: Union[PaddingMode, str, Scalar] = PaddingMode.BORDER,
-        align_centers: bool = False,
-        flip_coords: bool = False,
-    ) -> None:
-        r"""Initialize spatial image transformer.
+    def __init__(self, transform: SpatialTransform) -> None:
+        r"""Initialize spatial transformer.
 
         Args:
-            transform: Spatial coordinate transformation which is applied to ``target`` grid points.
-            target: Sampling grid of output images. If ``None``, use ``transform.axes()``.
-            source: Sampling grid of input images. If ``None``, use ``target``.
-            sampling: Image interpolation mode.
-            padding: Image extrapolation mode or scalar out-of-domain value.
-            align_centers: Whether to implicitly align the ``target`` and ``source`` centers.
-                If ``True``, only the affine component of the target to source transformation
-                is applied after the spatial grid ``transform``. If ``False``, also the
-                translation of grid center points is considered.
-            flip_coords: Whether spatial transformation applies to flipped grid point coordinates
-                in the order (z, y, x). The default is grid point coordinates in the order (x, y, z).
+            transform: Spatial coordinate transformation.
 
         """
         if not isinstance(transform, SpatialTransform):
             raise TypeError(
                 f"{type(self).__name__}() requires 'transform' of type SpatialTransform"
             )
-        if target is None:
-            target = transform.grid()
-        if source is None:
-            source = target
-        if not isinstance(target, Grid):
-            raise TypeError(f"{type(self).__name__}() 'target' must be of type Grid")
-        if not isinstance(source, Grid):
-            raise TypeError(f"{type(self).__name__}() 'source' must be of type Grid")
-        if not transform.grid().same_domain_as(target):
-            raise ValueError(
-                f"{type(self).__name__}() 'target' and 'transform' grid must define the same domain"
-            )
         super().__init__()
         self._transform = transform
-        self._sample = SampleImage(
-            target=target,
-            source=source,
-            sampling=sampling,
-            padding=padding,
-            align_centers=align_centers,
-        )
-        grid_coords = target.coords(flip=flip_coords).unsqueeze(0)
-        self.register_buffer("grid_coords", grid_coords, persistent=False)
-        self.flip_coords = bool(flip_coords)
 
     @overload
     def condition(self) -> Tuple[tuple, dict]:
@@ -118,6 +84,73 @@ class ImageTransformer(Module):
     def transform(self) -> SpatialTransform:
         r"""Spatial grid transformation."""
         return self._transform
+
+
+class ImageTransformer(SpatialTransformer):
+    r"""Spatially transform an image.
+
+    The :class:`.ImageTransformer` applies a :class:`.SpatialTransform` to the sampling grid
+    points of the target domain, optionally followed by linear transformation from target to
+    source domain, and samples the input image of shape ``(N, C, ..., X)`` at these deformed
+    source grid points. If the spatial transformation is non-rigid, this is also commonly
+    referred to as warping the input image.
+
+    Note that the :meth:`.ImageTransformer.forward` method invokes the spatial transform as
+    functor, i.e., it triggers any pre-forward and post-forward hooks that are registered
+    with the spatial transform when evaluating it. This includes in particular the
+    :meth:`.SpatialTransform.update_hook` (see also :class:`.SpatialTransformer`).
+
+    """
+
+    def __init__(
+        self,
+        transform: SpatialTransform,
+        target: Optional[Grid] = None,
+        source: Optional[Grid] = None,
+        sampling: Union[Sampling, str] = Sampling.LINEAR,
+        padding: Union[PaddingMode, str, Scalar] = PaddingMode.BORDER,
+        align_centers: bool = False,
+        flip_coords: bool = False,
+    ) -> None:
+        r"""Initialize spatial image transformer.
+
+        Args:
+            transform: Spatial coordinate transformation which is applied to ``target`` grid points.
+            target: Sampling grid of output images. If ``None``, use ``transform.axes()``.
+            source: Sampling grid of input images. If ``None``, use ``target``.
+            sampling: Image interpolation mode.
+            padding: Image extrapolation mode or scalar out-of-domain value.
+            align_centers: Whether to implicitly align the ``target`` and ``source`` centers.
+                If ``True``, only the affine component of the target to source transformation
+                is applied after the spatial grid ``transform``. If ``False``, also the
+                translation of grid center points is considered.
+            flip_coords: Whether spatial transformation applies to flipped grid point coordinates
+                in the order (z, y, x). The default is grid point coordinates in the order (x, y, z).
+
+        """
+        super().__init__(transform)
+        if target is None:
+            target = transform.grid()
+        if source is None:
+            source = target
+        if not isinstance(target, Grid):
+            raise TypeError(f"{type(self).__name__}() 'target' must be of type Grid")
+        if not isinstance(source, Grid):
+            raise TypeError(f"{type(self).__name__}() 'source' must be of type Grid")
+        if not transform.grid().same_domain_as(target):
+            raise ValueError(
+                f"{type(self).__name__}() 'target' and 'transform' grid must define the same domain"
+            )
+        self._sample = SampleImage(
+            target=target,
+            source=source,
+            sampling=sampling,
+            padding=padding,
+            align_centers=align_centers,
+        )
+        grid_coords = target.coords(flip=flip_coords).unsqueeze(0)
+        self.register_buffer("grid_coords", grid_coords, persistent=False)
+        self.flip_coords = bool(flip_coords)
 
     @property
     def sample(self) -> SampleImage:
@@ -164,13 +197,19 @@ class ImageTransformer(Module):
         return self._sample(grid, data, mask)
 
 
-class PointSetTransformer(Module):
+class PointSetTransformer(SpatialTransformer):
     r"""Spatially transform a set of points.
 
     The :class:`.PointSetTransformer` applies a :class:`.SpatialTransform` to a set of input points
     with coordinates defined with respect to a specified target domain. This coordinate map may
     further be followed by a linear transformation from the grid domain of the spatial transform
     to a given source domain. When no spatial transform is given, use :func:`.grid_transform_points`.
+
+    The forward method of a point set transformer performs the same operation as :meth:`.SpatialTransform.points`,
+    but with the target and source domain arguments specified during transformer initialization. In addition,
+    the point set transformer module invokes the spatial transform as a functor such that any registered
+    pre-forward and post-forward hooks are executed as part of the spatial transform evaluation. This includes
+    in particular the :meth:`.SpatialTransform.update_hook` (see also :class:`.SpatialTransformer`).
 
     """
 
@@ -184,8 +223,6 @@ class PointSetTransformer(Module):
     ) -> None:
         r"""Initialize point set transformer.
 
-        This point set transformer calls :meth:`.SpatialTransform.points` with the specified module attributes.
-
         Args:
             transform: Spatial coordinate transformation which is applied to input points.
             grid: Grid with respect to which input points are defined. Uses ``transform.grid()`` if ``None``.
@@ -194,8 +231,7 @@ class PointSetTransformer(Module):
             to_axes: Coordinate axes to which input points should be mapped to. Same as ``axes`` if ``None``.
 
         """
-        if not isinstance(transform, SpatialTransform):
-            raise TypeError(f"{type(self).__name__}() 'transform' must be a SpatialTransform")
+        super().__init__(transform)
         if grid is None:
             grid = transform.grid()
         if axes is None:
@@ -208,44 +244,10 @@ class PointSetTransformer(Module):
             to_axes = axes
         else:
             to_axes = Axes.from_arg(to_axes)
-        super().__init__()
-        self._transform = transform
         self._grid = grid
         self._axes = axes
         self._to_grid = to_grid
         self._to_axes = to_axes
-
-    @overload
-    def condition(self) -> Tuple[tuple, dict]:
-        r"""Get arguments on which transformation is conditioned.
-
-        Returns:
-            args: Positional arguments.
-            kwargs: Keyword arguments.
-
-        """
-        ...
-
-    @overload
-    def condition(self, *args, **kwargs) -> PointSetTransformer:
-        r"""Get new transformation which is conditioned on the specified arguments."""
-        ...
-
-    def condition(self, *args, **kwargs) -> Union[PointSetTransformer, Tuple[tuple, dict]]:
-        r"""Get or set data tensors and parameters on which transformation is conditioned."""
-        if args:
-            return shallow_copy(self).condition_(*args)
-        return self._transform.condition()
-
-    def condition_(self, *args, **kwargs) -> PointSetTransformer:
-        r"""Set data tensors and parameters on which this transformation is conditioned."""
-        self._transform.condition_(*args, **kwargs)
-        return self
-
-    @property
-    def transform(self) -> SpatialTransform:
-        r"""Spatial transformation."""
-        return self._transform
 
     def target_axes(self) -> Axes:
         r"""Coordinate axes with respect to which input points are defined."""
@@ -265,10 +267,20 @@ class PointSetTransformer(Module):
 
     def forward(self, points: Tensor) -> Tensor:
         r"""Spatially transform a set of points."""
-        return self._transform.points(
+        transform = self.transform
+        points = self._grid.transform_points(
             points,
-            grid=self._grid,
             axes=self._axes,
+            to_grid=transform.grid(),
+            to_axes=transform.axes(),
+            decimals=None,
+        )
+        points = transform(points)
+        points = transform.grid().transform_points(
+            points,
+            axes=transform.axes(),
             to_grid=self._to_grid,
             to_axes=self._to_axes,
+            decimals=None,
         )
+        return points


### PR DESCRIPTION
This PR also fixes up the `PointSetTransformer` added earlier today. Every spatial transformer should invoke the spatial transform as functor such that the update hook is being invoked prior to calling the forward method. The newly added `SpatialTransform.remove_update_hook()` and `SpatialTransform.register_update_hook()` methods can be used to control when the `SpatialTransform.update_hook()` is registered. This is in particular done during initialization of a `SpatialTransform`.