### PR TITLE
[losses] Add global normalized cross correlation

### DIFF
--- a/src/deepali/losses/__init__.py
+++ b/src/deepali/losses/__init__.py
@@ -38,6 +38,7 @@ from .flow import TotalVariation, TV
 
 from .image import PatchwiseImageLoss, PatchLoss
 from .image import Dice, DSC
+from .image import NCC
 from .image import LCC, LNCC
 from .image import SLCC, WLCC
 from .image import MI, NMI
@@ -99,6 +100,7 @@ __all__ = (
     "MAE",
     "MI",
     "MSE",
+    "NCC",
     "NMI",
     "SLCC",
     "SmoothL1ImageLoss",

--- a/src/deepali/losses/image.py
+++ b/src/deepali/losses/image.py
@@ -30,6 +30,26 @@ class Dice(PairwiseImageLoss):
 DSC = Dice
 
 
+class NCC(PairwiseImageLoss):
+    r"""Normalized cross correlation."""
+
+    def __init__(self, epsilon: float = 1e-15) -> None:
+        super().__init__()
+        self.epsilon = epsilon
+
+    def forward(self, source: Tensor, target: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+        r"""Evaluate image dissimilarity loss."""
+        return L.ncc_loss(
+            source,
+            target,
+            mask=mask,
+            epsilon=self.epsilon,
+        )
+
+    def extra_repr(self) -> str:
+        return f"epsilon={self.epsilon:.2e}"
+
+
 class LCC(PairwiseImageLoss):
     r"""Local normalized cross correlation."""
 


### PR DESCRIPTION
Add pairwise `ncc_loss()` function and `NCC` loss. Unlike `lcc_loss()` and `LCC`, these compute the normalized cross correlation over the entire image grid rather than local rectangular windows.