### PR TITLE
Fix and extend flow derivatives and losses

### DIFF
--- a/src/deepali/core/functional.py
+++ b/src/deepali/core/functional.py
@@ -59,10 +59,6 @@ from .linalg import vector_rotation
 from .bspline import bspline_interpolation_weights
 from .bspline import cubic_bspline_control_point_grid
 from .bspline import cubic_bspline_control_point_grid_size
-from .bspline import cubic_bspline_jacobian_det
-from .bspline import cubic_bspline_jacobian_dict
-from .bspline import cubic_bspline_jacobian_matrix
-from .bspline import cubic_bspline_jacobian_triu
 from .bspline import evaluate_cubic_bspline
 from .bspline import subdivide_cubic_bspline
 
@@ -97,9 +93,16 @@ from .image import zeros_image
 
 from .flow import affine_flow
 from .flow import compose_flows
+from .flow import curl
 from .flow import denormalize_flow
+from .flow import divergence
+from .flow import divergence_free_flow
 from .flow import expv
+from .flow import flow_derivatives
 from .flow import jacobian_det
+from .flow import jacobian_dict
+from .flow import jacobian_matrix
+from .flow import jacobian_triu
 from .flow import normalize_flow
 from .flow import sample_flow
 from .flow import warp_grid
@@ -186,13 +189,12 @@ __all__ = (
     "cshape_image",
     "cubic_bspline_control_point_grid",
     "cubic_bspline_control_point_grid_size",
-    "cubic_bspline_jacobian_det",
-    "cubic_bspline_jacobian_dict",
-    "cubic_bspline_jacobian_matrix",
-    "cubic_bspline_jacobian_triu",
+    "curl",
     "denormalize_flow",
     "denormalize_grid",
     "distance_matrix",
+    "divergence",
+    "divergence_free_flow",
     "dot_batch",
     "dot_channels",
     "downsample",
@@ -201,6 +203,7 @@ __all__ = (
     "expv",
     "flatten_channels",
     "finite_differences",
+    "flow_derivatives",
     "gaussian_pyramid",
     "grid_image",
     "image_slice",
@@ -212,6 +215,9 @@ __all__ = (
     "grid_sample",
     "grid_sample_mask",
     "jacobian_det",
+    "jacobian_dict",
+    "jacobian_matrix",
+    "jacobian_triu",
     "max_pool",
     "min_pool",
     "normalize_flow",

--- a/src/deepali/losses/bspline.py
+++ b/src/deepali/losses/bspline.py
@@ -11,7 +11,7 @@ class BSplineBending(BSplineLoss):
 
     def forward(self, params: Tensor) -> Tensor:
         r"""Evaluate loss term for given free form deformation parameters."""
-        return L.bspline_bending_loss(params, stride=self.stride, reduction=self.reduction)
+        return L.bending_loss(params, mode="bspline", stride=self.stride, reduction=self.reduction)
 
 
 BSplineBendingEnergy = BSplineBending

--- a/src/deepali/modules/__init__.py
+++ b/src/deepali/modules/__init__.py
@@ -12,6 +12,7 @@ from .basic import Pad
 from .basic import Reshape
 from .basic import View
 
+from .flow import Curl
 from .flow import ExpFlow
 
 from .image import BlurImage
@@ -37,6 +38,7 @@ from .utilities import rename_layers_in_state_dict
 __all__ = (
     "AlignImage",
     "BlurImage",
+    "Curl",
     "DeviceProperty",
     "ExpFlow",
     "FilterImage",

--- a/src/deepali/modules/flow.py
+++ b/src/deepali/modules/flow.py
@@ -3,13 +3,46 @@ r"""Modules operating on flow vector fields."""
 from __future__ import annotations
 
 from copy import copy as shallow_copy
-from typing import Optional
+from typing import Optional, Union
 
 from torch import Tensor
 from torch.nn import Module
 
 from deepali.core import ALIGN_CORNERS
+from deepali.core import Array, Scalar, ScalarOrTuple
 from deepali.core import functional as U
+
+
+class Curl(Module):
+    r"""Layer which calculates the curl of a vector field."""
+
+    def __init__(
+        self,
+        mode: Optional[str] = None,
+        sigma: Optional[float] = None,
+        spacing: Optional[Union[Scalar, Array]] = None,
+        stride: Optional[ScalarOrTuple[int]] = None,
+    ) -> None:
+        super().__init__()
+        self.mode = mode
+        self.sigma = sigma
+        self.spacing = spacing
+        self.stride = stride
+
+    def forward(self, x: Tensor) -> Tensor:
+        return U.curl(x, mode=self.mode, sigma=self.sigma, spacing=self.spacing, stride=self.stride)
+
+    def extra_repr(self) -> str:
+        args = []
+        if self.mode is not None:
+            args.append(f"mode={self.mode!r}")
+        if self.sigma is not None:
+            args.append(f"sigma={self.sigma!r}")
+        if self.spacing is not None:
+            args.append(f"spacing={self.spacing!r}")
+        if self.stride is not None:
+            args.append(f"stride={self.stride!r}")
+        return ", ".join(args)
 
 
 class ExpFlow(Module):

--- a/tests/test_core_enum.py
+++ b/tests/test_core_enum.py
@@ -1,0 +1,139 @@
+import itertools
+
+import pytest
+
+from deepali.core.enum import FlowChannelIndex, FlowDerivativeKeys
+from deepali.core.enum import SpatialDerivativeKeys, SpatialDim
+
+
+def test_flow_derivative_keys_from_arg() -> None:
+    for D, order in itertools.product([2, 3], [0, 1, 2]):
+        keys = FlowDerivativeKeys.from_arg(spatial_dims=D, order=1)
+        expected = FlowDerivativeKeys.all(spatial_dims=D, order=1)
+        assert keys == expected
+
+    keys = ["du/dx", "du/dxx", "dv/dy", "dv/dxy"]
+    assert FlowDerivativeKeys.from_arg(spatial_dims=2, which=keys) == keys
+    assert FlowDerivativeKeys.from_arg(spatial_dims=2, which=keys, order=0) == []
+    assert FlowDerivativeKeys.from_arg(spatial_dims=2, which=keys, order=1) == ["du/dx", "dv/dy"]
+    assert FlowDerivativeKeys.from_arg(spatial_dims=2, which=keys, order=2) == ["du/dxx", "dv/dxy"]
+
+    assert FlowDerivativeKeys.from_arg(spatial_dims=2, which="x") == ["du/dx", "dv/dx"]
+    assert FlowDerivativeKeys.from_arg(spatial_dims=3, which="x") == ["du/dx", "dv/dx", "dw/dx"]
+
+
+def test_flow_derivative_keys_split() -> None:
+    assert FlowDerivativeKeys.split("du/dx") == (FlowChannelIndex.U, "x")
+    assert FlowDerivativeKeys.split("du/dxy") == (FlowChannelIndex.U, "xy")
+    assert FlowDerivativeKeys.split("dv/dzy") == (FlowChannelIndex.V, "zy")
+    assert FlowDerivativeKeys.split("dw/dxxyz") == (FlowChannelIndex.W, "xxyz")
+
+    assert FlowDerivativeKeys.split(["du/dxy", "dv/dzy"]) == [
+        (FlowChannelIndex.U, "xy"),
+        (FlowChannelIndex.V, "zy"),
+    ]
+
+
+def test_flow_derivative_keys_symbol() -> None:
+    assert FlowDerivativeKeys.symbol(0, 0) == "du/dx"
+    assert FlowDerivativeKeys.symbol(0, 1) == "du/dy"
+    assert FlowDerivativeKeys.symbol(0, 2) == "du/dz"
+    assert FlowDerivativeKeys.symbol(0, 3) == "du/dt"
+
+    assert FlowDerivativeKeys.symbol(1, 0) == "dv/dx"
+    assert FlowDerivativeKeys.symbol(1, 1) == "dv/dy"
+    assert FlowDerivativeKeys.symbol(1, 2) == "dv/dz"
+    assert FlowDerivativeKeys.symbol(1, 3) == "dv/dt"
+
+    assert FlowDerivativeKeys.symbol(2, 0) == "dw/dx"
+    assert FlowDerivativeKeys.symbol(2, 1) == "dw/dy"
+    assert FlowDerivativeKeys.symbol(2, 2) == "dw/dz"
+    assert FlowDerivativeKeys.symbol(2, 3) == "dw/dt"
+
+    assert FlowDerivativeKeys.symbol("u", 0, "y", SpatialDim.Z) == "du/dxyz"
+    assert FlowDerivativeKeys.symbol("v", "xyz") == "dv/dxyz"
+
+    with pytest.raises(TypeError):
+        FlowDerivativeKeys.symbol(0, 2.3)
+
+
+def test_flow_derivative_keys_unique() -> None:
+    value = FlowDerivativeKeys.unique("du/dx")
+    assert isinstance(value, str)
+    assert value == "du/dx"
+
+    value = FlowDerivativeKeys.unique(["du/dx"])
+    assert isinstance(value, set)
+    assert value == {"du/dx"}
+
+    assert FlowDerivativeKeys.unique(["du/dxy", "du/dyx"]) == {"du/dxy"}
+    assert FlowDerivativeKeys.unique(["du/dz", "du/dxy", "du/dyx"]) == {"du/dxy", "du/dz"}
+    assert FlowDerivativeKeys.unique(["dv/dxy", "du/dxy", "du/dyx"]) == {"du/dxy", "dv/dxy"}
+
+
+def test_flow_derivative_keys_all() -> None:
+    for d, order in itertools.product([2, 3], [0, 1, 2]):
+        channel_keys = ["u", "v", "w"][:d]
+        spatial_keys = SpatialDerivativeKeys.all(ndim=d, order=order)
+        expected = [f"d{a}/d{b}" for a, b in itertools.product(channel_keys, spatial_keys)]
+        assert FlowDerivativeKeys.all(spatial_dims=d, order=order) == expected
+
+
+def test_flow_derivative_keys_gradient() -> None:
+    assert FlowDerivativeKeys.gradient(spatial_dims=3, channel="v") == [
+        "dv/dx",
+        "dv/dy",
+        "dv/dz",
+    ]
+    assert FlowDerivativeKeys.gradient(spatial_dims=3, channel=[0, "v"]) == [
+        # fmt: off
+        "du/dx", "du/dy", "du/dz",
+        "dv/dx", "dv/dy", "dv/dz",
+        # fmt: on
+    ]
+
+
+def test_flow_derivative_keys_jacobian() -> None:
+    for d in [2, 3]:
+        expected = FlowDerivativeKeys.all(spatial_dims=d, order=1)
+        assert FlowDerivativeKeys.jacobian(spatial_dims=d) == expected
+
+
+def test_flow_derivative_keys_divergence() -> None:
+    assert FlowDerivativeKeys.divergence(spatial_dims=2) == ["du/dx", "dv/dy"]
+    assert FlowDerivativeKeys.divergence(spatial_dims=3) == ["du/dx", "dv/dy", "dw/dz"]
+
+
+def test_flow_derivative_keys_curvature() -> None:
+    assert FlowDerivativeKeys.curvature(spatial_dims=2) == [
+        # fmt: off
+        "du/dxx", "du/dyy",
+        "dv/dxx", "dv/dyy",
+        # fmt: on
+    ]
+    assert FlowDerivativeKeys.curvature(spatial_dims=3) == [
+        # fmt: off
+        "du/dxx", "du/dyy", "du/dzz",
+        "dv/dxx", "dv/dyy", "dv/dzz",
+        "dw/dxx", "dw/dyy", "dw/dzz",
+        # fmt: on
+    ]
+
+
+def test_flow_derivative_keys_hessian() -> None:
+    for d, c in itertools.product([2, 3], [None, "u", "v", ["u", "v"]]):
+        expected = FlowDerivativeKeys.all(spatial_dims=d, channel=c, order=2)
+        assert FlowDerivativeKeys.hessian(spatial_dims=d, channel=c) == expected
+
+
+def test_flow_derivative_keys_unmixed() -> None:
+    for d, order in itertools.product([2, 3], [0, 1, 2]):
+        if order == 0:
+            expected = []
+        elif order == 1:
+            expected = FlowDerivativeKeys.all(spatial_dims=d, order=1)
+        elif order == 2:
+            expected = FlowDerivativeKeys.curvature(spatial_dims=d)
+        else:
+            raise AssertionError(f"unexpected order: {order}")
+        assert FlowDerivativeKeys.unmixed(spatial_dims=d, order=order) == expected

--- a/tests/test_core_flow_utils.py
+++ b/tests/test_core_flow_utils.py
@@ -1,0 +1,237 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from deepali.core import Grid
+from deepali.core.enum import FlowDerivativeKeys
+import deepali.core.functional as U
+
+
+PERIODIC_FLOW_X_SCALE = 2 * torch.pi
+PERIODIC_FLOW_U_SCALE = 0.1
+
+
+def periodic_flow(p: Tensor) -> Tensor:
+    q = p.mul(PERIODIC_FLOW_X_SCALE)
+    u = q.narrow(1, 0, 1).sin().neg_()
+    v = q.narrow(1, 1, 1).cos()
+    f = torch.cat([u, v], dim=1)
+    return f.mul_(PERIODIC_FLOW_U_SCALE)
+
+
+def periodic_flow_du_dx(p: Tensor) -> Tensor:
+    q = p.mul(PERIODIC_FLOW_X_SCALE)
+    g = q.narrow(1, 0, 1).cos()
+    g = g.mul_(-PERIODIC_FLOW_X_SCALE * PERIODIC_FLOW_U_SCALE)
+    return g
+
+
+def periodic_flow_du_dy(p: Tensor) -> Tensor:
+    return torch.zeros((p.shape[0], 1) + p.shape[2:], dtype=p.dtype, device=p.device)
+
+
+def periodic_flow_du_dxx(p: Tensor) -> Tensor:
+    q = p.mul(PERIODIC_FLOW_X_SCALE)
+    g = q.narrow(1, 0, 1).sin()
+    g = g.mul_(PERIODIC_FLOW_X_SCALE * PERIODIC_FLOW_X_SCALE * PERIODIC_FLOW_U_SCALE)
+    return g
+
+
+def periodic_flow_du_dyy(p: Tensor) -> Tensor:
+    return torch.zeros((p.shape[0], 1) + p.shape[2:], dtype=p.dtype, device=p.device)
+
+
+def periodic_flow_dv_dx(p: Tensor) -> Tensor:
+    return torch.zeros((p.shape[0], 1) + p.shape[2:], dtype=p.dtype, device=p.device)
+
+
+def periodic_flow_dv_dy(p: Tensor) -> Tensor:
+    q = p.mul(PERIODIC_FLOW_X_SCALE)
+    g = q.narrow(1, 1, 1).sin()
+    g = g.mul_(-PERIODIC_FLOW_X_SCALE * PERIODIC_FLOW_U_SCALE)
+    return g
+
+
+def periodic_flow_dv_dxx(p: Tensor) -> Tensor:
+    return torch.zeros((p.shape[0], 1) + p.shape[2:], dtype=p.dtype, device=p.device)
+
+
+def periodic_flow_dv_dyy(p: Tensor) -> Tensor:
+    q = p.mul(PERIODIC_FLOW_X_SCALE)
+    g = q.narrow(1, 1, 1).cos()
+    g = g.mul_(-PERIODIC_FLOW_X_SCALE * PERIODIC_FLOW_X_SCALE * PERIODIC_FLOW_U_SCALE)
+    return g
+
+
+def periodic_flow_deriv(p: Tensor, which: str) -> Tensor:
+    deriv_fn = {
+        "du/dx": periodic_flow_du_dx,
+        "du/dy": periodic_flow_du_dy,
+        "dv/dx": periodic_flow_dv_dx,
+        "dv/dy": periodic_flow_dv_dy,
+        "du/dxx": periodic_flow_du_dxx,
+        "du/dyy": periodic_flow_du_dyy,
+        "dv/dxx": periodic_flow_dv_dxx,
+        "dv/dyy": periodic_flow_dv_dyy,
+    }
+    return deriv_fn[which](p)
+
+
+def periodic_flow_divergence(p: Tensor) -> Tensor:
+    du_dx = periodic_flow_du_dx(p)
+    dv_dy = periodic_flow_dv_dy(p)
+    return du_dx.add(dv_dy)
+
+
+def difference(a: Tensor, b: Tensor, margin: int = 0) -> Tensor:
+    assert a.shape == b.shape
+    i = [
+        slice(0, n, 1) if dim < 2 else slice(margin, n - margin, 1) for dim, n in enumerate(a.shape)
+    ]
+    return a[i].sub(b[i])
+
+
+def test_flow_curl() -> None:
+    # 2-dimensional vector field
+    p = U.move_dim(Grid(size=(32, 24)).coords().unsqueeze_(0), -1, 1)
+
+    x = p.narrow(1, 0, 1)
+    y = p.narrow(1, 1, 1)
+
+    flow = torch.cat([y.neg(), x], dim=1)
+
+    curl = U.curl(flow)
+    assert isinstance(curl, Tensor)
+    assert curl.shape == (flow.shape[0], 1) + flow.shape[2:]
+    assert curl.dtype == flow.dtype
+    assert curl.device == flow.device
+    assert curl.sub(2).abs().lt(1e-6).all()
+
+    # 3-dimensional vector field
+    p = U.move_dim(Grid(size=(64, 32, 16)).coords().unsqueeze_(0), -1, 1)
+
+    x = p.narrow(1, 0, 1)
+    y = p.narrow(1, 1, 1)
+    z = p.narrow(1, 2, 1)
+
+    flow = torch.cat([x.mul(z), y.mul(z), x.mul(y)], dim=1)
+
+    curl = U.curl(flow)
+    assert isinstance(curl, Tensor)
+    assert curl.shape == flow.shape
+    assert curl.dtype == flow.dtype
+    assert curl.device == flow.device
+
+    expected = x.sub(y)
+    expected = torch.cat([expected, expected, torch.zeros_like(expected)], dim=1)
+    error = difference(curl, expected, margin=1)
+    assert error.abs().max().lt(1e-5)
+
+    div = U.divergence(curl)
+    assert div.abs().max().lt(1e-5)
+
+
+def test_flow_derivatives() -> None:
+    # 2D vector field defined by periodic functions
+    p = U.move_dim(Grid(size=(120, 100)).coords().unsqueeze_(0), -1, 1)
+
+    flow = periodic_flow(p)
+
+    which = FlowDerivativeKeys.all(spatial_dims=2, order=1)
+    which.append("du/dxx")
+    which.append("dv/dyy")
+
+    deriv = U.flow_derivatives(flow, which=which)
+    assert isinstance(deriv, dict)
+    assert all(isinstance(k, str) for k in deriv.keys())
+    assert all(isinstance(v, Tensor) for v in deriv.values())
+    assert all(v.shape == (flow.shape[0], 1) + flow.shape[2:] for v in deriv.values())
+
+    for key, value in deriv.items():
+        expected = periodic_flow_deriv(p, key)
+        order = FlowDerivativeKeys.order(key)
+        dif = difference(value, expected, margin=order)
+        tol = 0.003 * (10 ** (order - 1))
+        assert dif.abs().max().lt(tol), f"flow derivative {key}"
+
+    # 3D vector field
+    p = U.move_dim(Grid(size=(64, 32, 16)).coords().unsqueeze_(0), -1, 1)
+
+    x = p.narrow(1, 0, 1)
+    y = p.narrow(1, 1, 1)
+    z = p.narrow(1, 2, 1)
+
+    flow = torch.cat([x.mul(z), y.mul(z), x.mul(y)], dim=1)
+
+    deriv = U.flow_derivatives(flow, order=1)
+
+    assert difference(deriv["du/dx"], z).abs().max().lt(1e-5)
+    assert deriv["du/dy"].abs().max().lt(1e-5)
+    assert difference(deriv["du/dz"], x).abs().max().lt(1e-5)
+
+    assert deriv["dv/dx"].abs().max().lt(1e-5)
+    assert difference(deriv["dv/dy"], z).abs().max().lt(1e-5)
+    assert difference(deriv["dv/dz"], y).abs().max().lt(1e-5)
+
+    assert difference(deriv["dw/dx"], y).abs().max().lt(1e-5)
+    assert difference(deriv["dw/dy"], x).abs().max().lt(1e-5)
+    assert deriv["dw/dz"].abs().max().lt(1e-5)
+
+
+def test_flow_divergence() -> None:
+    grid = Grid(size=(16, 14))
+    offset = U.translation([0.1, 0.2]).unsqueeze_(0)
+    flow = U.affine_flow(offset, grid)
+    div = U.divergence(flow)
+    assert isinstance(div, Tensor)
+    assert div.shape == (flow.shape[0], 1) + flow.shape[2:]
+    assert div.abs().max().lt(1e-5)
+
+    points = U.move_dim(Grid(size=(64, 64)).coords().unsqueeze_(0), -1, 1)
+    flow = periodic_flow(points)
+    div = U.divergence(flow)
+    assert isinstance(div, Tensor)
+    assert div.shape == (flow.shape[0], 1) + flow.shape[2:]
+    expected = periodic_flow_divergence(points)
+    dif = difference(div, expected, margin=1)
+    assert dif.abs().max().lt(0.01)
+
+    p = U.move_dim(Grid(size=(64, 32, 16)).coords().unsqueeze_(0), -1, 1)
+    x = p.narrow(1, 0, 1)
+    y = p.narrow(1, 1, 1)
+    z = p.narrow(1, 2, 1)
+    flow = torch.cat([x.mul(z), y.mul(z), x.mul(y)], dim=1)
+    div = U.divergence(flow)
+    assert isinstance(div, Tensor)
+    assert div.shape == (flow.shape[0], 1) + flow.shape[2:]
+    error = difference(div, z.mul(2))
+    assert error.abs().max().lt(1e-5)
+
+
+def test_flow_divergence_free() -> None:
+    data = torch.randn((1, 1, 16, 24)).mul_(0.01)
+    flow = U.divergence_free_flow(data)
+    assert flow.shape == (data.shape[0], 2) + data.shape[2:]
+    div = U.divergence(flow)
+    assert div.abs().max().lt(1e-5)
+
+    data = torch.randn((3, 2, 16, 24, 32)).mul_(0.01)
+    flow = U.divergence_free_flow(data, sigma=2.0)
+    assert flow.shape == (data.shape[0], 3) + data.shape[2:]
+    div = U.divergence(flow)
+    assert div[0, 0, 1:-1, 1:-1, 1:-1].abs().max().lt(1e-4)
+
+    coef = F.pad(data, (1, 2, 1, 2, 1, 2))
+    flow = U.divergence_free_flow(coef, mode="bspline", sigma=0.8)
+    assert flow.shape == (data.shape[0], 3) + data.shape[2:]
+    div = U.divergence(flow)
+    assert div[0, 0, 1:-1, 1:-1, 1:-1].abs().max().lt(1e-4)
+
+    # constructing a divergence-free field using curl() seems to work best given
+    # the higher magnitude and no need for Gaussian blurring of the random field
+    # where each component is sampled i.i.d. from a normal distribution
+    data = torch.randn((5, 3, 16, 24, 32)).mul_(0.2)
+    flow = U.divergence_free_flow(data)
+    assert flow.shape == data.shape
+    div = U.divergence(flow)
+    assert div.abs().max().lt(1e-4)

--- a/tests/test_losses_flow.py
+++ b/tests/test_losses_flow.py
@@ -1,0 +1,23 @@
+import torch
+
+from deepali.core import Grid
+import deepali.core.functional as U
+import deepali.losses.functional as L
+
+
+def test_losses_flow_bending() -> None:
+    data = torch.randn((1, 2, 16, 24))
+    a = L.bending_energy(data, mode="bspline", stride=1, reduction="none")
+    b = L.bspline_bending_energy(data, stride=1, reduction="none")
+    assert torch.allclose(a, b)
+
+
+def test_losses_flow_curvature() -> None:
+    grid = Grid(size=(16, 14))
+    offset = U.translation([0.1, 0.2]).unsqueeze_(0)
+    flow = U.affine_flow(offset, grid)
+    flow.requires_grad = True
+    loss = L.curvature_loss(flow)
+    assert loss.requires_grad
+    loss = loss.detach()
+    assert loss.abs().max().lt(1e-5)


### PR DESCRIPTION
- Add `flow_derivatives()` with default `spacing` for finite differences calculation assuming a normalized flow field.
- Add `curl()`, `divergence()`, and `divergence_free_flow()` functions to core library.
- Modify `finite_differences()` to pad input using `replicate` instead of padding output with zeros.
- Add `mode='forward_central_backward'` to avoid padding using `replicate` or `constant` values.
- Add `mode='bspline'` to `spatial_derivatives()`.
- Generalize `cubic_bspline_jacobian_*()` to `jacobian_*()` functions for all `mode` values.
- Fix bending energy, curvature, and divergence loss functions.

Fixes #113, #114, #115, and #116.